### PR TITLE
BTN2 on the booster pack is mapped to PE_0

### DIFF
--- a/lab/projects/Project_RPS/Game_UI.ino
+++ b/lab/projects/Project_RPS/Game_UI.ino
@@ -14,7 +14,7 @@ static enum GamePages
 const uint32_t SwitchCount = 2;
 const uint32_t ButtonCount = 2;
 const uint32_t Switches[SwitchCount] = { PA_7, PA_6 };
-const uint32_t Buttons[ButtonCount] = { PD_2, PE_1 };
+const uint32_t Buttons[ButtonCount] = { PD_2, PE_0 };
 const uint32_t Potentiometer = PE_3;
 const size_t   MaximumPlayers = 6;
 


### PR DESCRIPTION
Edited the Buttons array to use PE_0 instead of PE_1